### PR TITLE
[OMNI-32061] Fix httpGet return

### DIFF
--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -123,7 +123,9 @@ class RemoteConfig
                     'timeout' => $timeout,
                 ]
             );
-            $cache->set($cacheKey, json_decode($response->getBody(), true), self::RC_CACHE_FALLBACK_TTL);
+
+            $currentCache = json_decode($response->getBody(), true);
+            $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         } catch (ConnectException $e) {
             $this->logError('Could not get data from Remote Config API', [
                 'current_cache' => $currentCache,
@@ -138,7 +140,7 @@ class RemoteConfig
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         }
 
-        return $cache->get($cacheKey);
+        return $currentCache;
     }
 
     private function cacheFallback()


### PR DESCRIPTION
We realized the return of httpGet's method was always 'null' when we run the command `cache:refresh:carriers`, causing an error on the flow. After some tests we got a conclusion: the microservice is fine, but the cache fallback doesn't. For a first moment, we've decided to return the result directly from the microservice (`json_decode($response->getBody(), true)`) instead of keep trying to get contents from the cache fallback.

As soon as possible we'll take a look at what's happening with it.