### PR TITLE
[OMNI-28518] Adding correct exception when client is not found in remote config

### DIFF
--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -158,7 +158,7 @@ class RemoteConfig
                 $exceptionMessage = $re->getMessage();
 
                 if ($re->getResponse()->getStatusCode() === 404)
-                    $exceptionMessage = "clienteId is invalid!";
+                    $exceptionMessage = "clientId is invalid!";
 
                 throw new HttpException($re->getResponse()->getStatusCode(), $exceptionMessage);
             }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -87,20 +87,13 @@ class RemoteConfig
 
         if ($hasCache) {
             $data = $cache->get($cacheKey);
-
             if (!$this->cacheFallback()->has($cacheKey)) {
                 $this->cacheFallback()->set($cacheKey, $data, self::RC_CACHE_FALLBACK_TTL);
             }
         } else {
-
-            try {
-                $data = $this->httpGet($uri);
-
-                if ($canAcessRedis) {
-                    $cache->set($cacheKey, $data, $this->cacheLifeTime);
-                }
-            } catch (HttpException $th) {
-                throw $th;
+            $data = $this->httpGet($uri);
+            if ($canAcessRedis) {
+                $cache->set($cacheKey, $data, $this->cacheLifeTime);
             }
         }
 
@@ -154,7 +147,7 @@ class RemoteConfig
                     'path' => $path,
                     'timeout' => $timeout,
                 ]);
-                
+
                 $exceptionMessage = $re->getMessage();
 
                 if ($re->getResponse()->getStatusCode() === 404)

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -147,16 +147,20 @@ class RemoteConfig
 
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         } catch (RequestException $re) {
-            $this->logError('Could not get data from Remote Config API because clienteId is invalid', [
-                'current_cache' => $currentCache,
-                'error_message' => $re->getMessage(),
-                'path' => $path,
-                'timeout' => $timeout,
-            ]);
             if ($re->hasResponse()) {
-                if ($re->getResponse()->getStatusCode() === 404) {
-                    throw new HttpException(404, "clienteId is invalid!");
-                }
+                $this->logError('Could not get data from Remote Config API', [
+                    'current_cache' => $currentCache,
+                    'error_message' => $re->getMessage(),
+                    'path' => $path,
+                    'timeout' => $timeout,
+                ]);
+                
+                $exceptionMessage = $re->getMessage();
+
+                if ($re->getResponse()->getStatusCode() === 404)
+                    $exceptionMessage = "clienteId is invalid!";
+
+                throw new HttpException($re->getResponse()->getStatusCode(), $exceptionMessage);
             }
         }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -5,8 +5,10 @@ namespace Linx\RemoteConfigClient;
 use GuzzleHttp\Client;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Simple\FilesystemCache;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Psr\SimpleCache\CacheInterface;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Arr;
 
 class RemoteConfig
@@ -90,9 +92,15 @@ class RemoteConfig
                 $this->cacheFallback()->set($cacheKey, $data, self::RC_CACHE_FALLBACK_TTL);
             }
         } else {
-            $data = $this->httpGet($uri);
-            if ($canAcessRedis) {
-                $cache->set($cacheKey, $data, $this->cacheLifeTime);
+
+            try {
+                $data = $this->httpGet($uri);
+
+                if ($canAcessRedis) {
+                    $cache->set($cacheKey, $data, $this->cacheLifeTime);
+                }
+            } catch (HttpException $th) {
+                throw $th;
             }
         }
 
@@ -138,6 +146,18 @@ class RemoteConfig
             }
 
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
+        } catch (RequestException $re) {
+            $this->logError('Could not get data from Remote Config API because clienteId is invalid', [
+                'current_cache' => $currentCache,
+                'error_message' => $re->getMessage(),
+                'path' => $path,
+                'timeout' => $timeout,
+            ]);
+            if ($re->hasResponse()) {
+                if ($re->getResponse()->getStatusCode() === 400) {
+                    throw new HttpException(404, "clienteId is invalid!");
+                }
+            }
         }
 
         return $currentCache;

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -154,7 +154,7 @@ class RemoteConfig
                 'timeout' => $timeout,
             ]);
             if ($re->hasResponse()) {
-                if ($re->getResponse()->getStatusCode() === 400) {
+                if ($re->getResponse()->getStatusCode() === 404) {
                     throw new HttpException(404, "clienteId is invalid!");
                 }
             }


### PR DESCRIPTION
In the RemoteConfig class, I made a new exception to catch the Http errors, and with that I was able to correctly throw the 404 error with the message clientId is invalid.